### PR TITLE
Add basic JWT authentication

### DIFF
--- a/CleanApiSample.Api/CleanApiSample.Api.csproj
+++ b/CleanApiSample.Api/CleanApiSample.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CleanApiSample.Api/Controllers/AuthController.cs
+++ b/CleanApiSample.Api/Controllers/AuthController.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace CleanApiSample.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private readonly IConfiguration _configuration;
+
+        public AuthController(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        [HttpPost("login")]
+        [AllowAnonymous]
+        public ActionResult<LoginResponse> Login([FromBody] LoginRequest request)
+        {
+            var configuredUser = _configuration["Jwt:UserName"]
+                ?? throw new InvalidOperationException("Jwt:UserName configuration is missing.");
+            var configuredPassword = _configuration["Jwt:Password"]
+                ?? throw new InvalidOperationException("Jwt:Password configuration is missing.");
+
+            if (!string.Equals(request.UserName, configuredUser, StringComparison.Ordinal) ||
+                !string.Equals(request.Password, configuredPassword, StringComparison.Ordinal))
+            {
+                return Unauthorized();
+            }
+
+            var token = GenerateToken(request.UserName);
+            return Ok(new LoginResponse(token));
+        }
+
+        private string GenerateToken(string userName)
+        {
+            var key = _configuration["Jwt:Key"]
+                ?? throw new InvalidOperationException("Jwt:Key configuration is missing.");
+            var issuer = _configuration["Jwt:Issuer"]
+                ?? throw new InvalidOperationException("Jwt:Issuer configuration is missing.");
+            var audience = _configuration["Jwt:Audience"]
+                ?? throw new InvalidOperationException("Jwt:Audience configuration is missing.");
+
+            var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, userName) }),
+                Expires = DateTime.UtcNow.AddHours(1),
+                Issuer = issuer,
+                Audience = audience,
+                SigningCredentials = credentials
+            };
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            return tokenHandler.WriteToken(token);
+        }
+
+        public record LoginRequest(string UserName, string Password);
+
+        public record LoginResponse(string Token);
+    }
+}

--- a/CleanApiSample.Api/Controllers/InvoiceController.cs
+++ b/CleanApiSample.Api/Controllers/InvoiceController.cs
@@ -6,12 +6,14 @@ using CleanApiSample.Application.Features.Products;
 using CleanApiSample.Application.Features.Products.Commands;
 using CleanApiSample.Application.Features.Products.Queries;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CleanApiSample.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class InvoiceController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/CleanApiSample.Api/Controllers/ProductsController.cs
+++ b/CleanApiSample.Api/Controllers/ProductsController.cs
@@ -3,12 +3,14 @@ using CleanApiSample.Application.Features.Products;
 using CleanApiSample.Application.Features.Products.Commands;
 using CleanApiSample.Application.Features.Products.Queries;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CleanApiSample.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class ProductsController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/CleanApiSample.Api/Program.cs
+++ b/CleanApiSample.Api/Program.cs
@@ -4,7 +4,10 @@ using CleanApiSample.Application.Features.Products;
 using CleanApiSample.Application.Features.Products.Commands;
 using CleanApiSample.Application.Features.Products.Queries;
 using CleanApiSample.Infraestructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,6 +24,30 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddInfraestructure(builder.Configuration);
+
+var jwtKey = builder.Configuration["Jwt:Key"] ?? throw new InvalidOperationException("Jwt:Key configuration is missing.");
+var jwtIssuer = builder.Configuration["Jwt:Issuer"] ?? throw new InvalidOperationException("Jwt:Issuer configuration is missing.");
+var jwtAudience = builder.Configuration["Jwt:Audience"] ?? throw new InvalidOperationException("Jwt:Audience configuration is missing.");
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = jwtIssuer,
+        ValidAudience = jwtAudience,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
+    };
+});
+
+builder.Services.AddAuthorization();
 
 #region [QC services]
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(GetProductsQuery).Assembly));
@@ -39,7 +66,35 @@ builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(GetIn
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c => c.SwaggerDoc("v1", new OpenApiInfo { Title = "CleanApiSample.Api", Version = "v1" }));
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "CleanApiSample.Api", Version = "v1" });
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Description = "JWT Authorization header using the Bearer scheme.",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT"
+    };
+
+    c.AddSecurityDefinition("Bearer", securityScheme);
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
 
 var app = builder.Build();
 
@@ -47,6 +102,9 @@ app.UseCors("AllowAll");
 
 app.UseSwagger();
 app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "CleanApiSample.Api v1"));
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 

--- a/CleanApiSample.Api/appsettings.Development.json
+++ b/CleanApiSample.Api/appsettings.Development.json
@@ -4,5 +4,12 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Jwt": {
+    "Key": "super_secret_development_key_1234567890",
+    "Issuer": "CleanApiSample",
+    "Audience": "CleanApiSample",
+    "UserName": "admin",
+    "Password": "admin123"
   }
 }

--- a/CleanApiSample.Api/appsettings.Production.json
+++ b/CleanApiSample.Api/appsettings.Production.json
@@ -1,5 +1,12 @@
 {
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=app_prod.db"
+  },
+  "Jwt": {
+    "Key": "super_secret_production_key_1234567890",
+    "Issuer": "CleanApiSample",
+    "Audience": "CleanApiSample",
+    "UserName": "admin",
+    "Password": "admin123"
   }
 }

--- a/CleanApiSample.Api/appsettings.json
+++ b/CleanApiSample.Api/appsettings.json
@@ -8,5 +8,12 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=app.db"
+  },
+  "Jwt": {
+    "Key": "super_secret_development_key_1234567890",
+    "Issuer": "CleanApiSample",
+    "Audience": "CleanApiSample",
+    "UserName": "admin",
+    "Password": "admin123"
   }
 }


### PR DESCRIPTION
## Summary
- add JWT bearer authentication package and configure the API pipeline to validate tokens
- protect existing invoice and product endpoints and expose a simple login endpoint that issues JWT tokens
- document JWT configuration values in appsettings files and wire bearer auth into Swagger

## Testing
- dotnet build *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b725b7488322bd031dd10f3b8e59